### PR TITLE
Removed =back.

### DIFF
--- a/cpanfile.pod
+++ b/cpanfile.pod
@@ -59,5 +59,3 @@ L<Gemfile|http://gembundler.com/man/gemfile.5.html> specification.
 =head1 SEE ALSO
 
 L<CPAN::Meta::Spec> L<Module::Install> L<Carton>
-
-=back


### PR DESCRIPTION
Noticed an error in the pod for cpanfile. It had an entry for =back, which didn't seem to be connected to an =over in the pod source.
