### PR TITLE
parse.t failed on ja locale

### DIFF
--- a/t/parse.t
+++ b/t/parse.t
@@ -3,16 +3,21 @@ use Module::CPANfile;
 use Test::More;
 use Cwd;
 use File::Basename qw(dirname);
+use POSIX qw(locale_h);
 use t::Utils;
 
 eval { require CPAN::Meta::Prereqs; 1 }
   or plan skip_all => "CPAN::Meta::Prereqs not found";
 
 {
+    # Use the traditional UNIX system locale to check the error message string.
+    my $old_locale = setlocale(LC_ALL);
+    setlocale(LC_ALL, 'C');
     eval {
         my $file = Module::CPANfile->load;
     };
     like $@, qr/No such file/;
+    setlocale(LC_ALL, $old_locale);
 }
 
 {


### PR DESCRIPTION
I ran "make test" and got following lines.

  #   Failed test at t/parse.t line 15.
  #                   '/tmp/cpanfile/cpanfile: そのようなファイルやディレクトリはありません at /tmp/cpanfile/blib/lib/Module/CPANfile.pm line 67.
  # '
  #     doesn't match '(?-xism:No such file)'

My patch fixed this issue.
