### PR TITLE
add a minimum version of CPAN::Meta::Prereqs to resolve test fails

### DIFF
--- a/t/merge.t
+++ b/t/merge.t
@@ -3,8 +3,11 @@ use Module::CPANfile;
 use Test::More;
 use t::Utils;
 
-eval { require CPAN::Meta::Prereqs; 1 }
-  or plan skip_all => "CPAN::Meta::Prereqs not found";
+eval {
+    require CPAN::Meta::Prereqs;
+    die unless $CPAN::Meta::Prereqs::VERSION >= 2.120921;
+    1;
+} or plan skip_all => "CPAN::Meta::Prereqs not found";
 
 {
     my $r = write_files(cpanfile => <<CPANFILE, 'META.json' => <<META);


### PR DESCRIPTION
I was seeing this:

``` Fetching
http://www.cpan.org/authors/id/M/MI/MIYAGAWA/Module-CPANfile-0.9008.tar.gz
-> OK Unpacking Module-CPANfile-0.9008.tar.gz Entering Module-CPANfile-0.9008
Checking configure dependencies from META.yml Checking if you have
ExtUtils::MakeMaker 6.31 ... Yes (6.64) Configuring Module-CPANfile-0.9008
Running Makefile.PL Checking if your kit is complete... Looks good Writing
Makefile for Module::CPANfile Writing MYMETA.yml and MYMETA.json
-> OK Checking dependencies from MYMETA.json ... Checking if you have
ExtUtils::MakeMaker 0 ... Yes (6.64) Building and testing
Module-CPANfile-0.9008 cp lib/cpanfile-faq.pod blib/lib/cpanfile-faq.pod cp
lib/Module/CPANfile.pm blib/lib/Module/CPANfile.pm cp lib/cpanfile.pod
blib/lib/cpanfile.pod Manifying blib/man3/Module::CPANfile.3pm Manifying
blib/man3/cpanfile-faq.3pm Manifying blib/man3/cpanfile.3pm PERL_DL_NONLAZY=1
/usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib',
'blib/arch')" t/*.t

t/merge.t .. Dubious, test returned 1 (wstat 256, 0x100) Failed 1/1 subtests
t/parse.t .. ok

Test Summary Report
------------------- t/merge.t (Wstat: 256 Tests: 1 Failed: 1)
 Failed test:  1
 Non-zero exit status: 1 Files=2, Tests=3,  1 wallclock secs ( 0.00 usr  0.01
sys +  0.06 cusr  0.01 csys =  0.08 CPU) Result: FAIL
```

The detail being:

```
  Failed test at t/merge.t line 59.
    Structures begin differing at:
         $got->{develop}{requires}{Catalyst::Runtime} = '0'
    $expected->{develop}{requires}{Catalyst::Runtime} = '> 5.8000, < 5.9'
Looks like you failed 1 test of 1. t/merge.t .. Dubious, test returned 1
(wstat 256, 0x100)
```

See also:
- http://www.cpantesters.org/cpan/report/5efecb86-6ef3-11e2-95b1-77473c106faF
- http://www.cpantesters.org/cpan/report/753a5c68-6c0e-11e2-8448-20cb30b64f85
- etc

Upgrading CPAN::Meta::Prereqs from 2.112621 to 2.120921 resolved the issue, so
we look for at least that level in the test suite now.
