### PR TITLE
Fix indication of line number at which an parsing error occurred.

### DIFF
--- a/lib/Module/CPANfile.pm
+++ b/lib/Module/CPANfile.pm
@@ -149,7 +149,11 @@ EVAL
         $err = $@;
     }
 
-    if ($err) { die "Parsing $file failed: $err" };
+    if ($err) {
+        my $line_diff = 5;
+        $err =~ s/line (\d*),/sprintf('line %d,', $1 - $line_diff)/e;
+        die "Parsing $file failed: $err";
+    }
 
     return $res;
 }

--- a/t/parse.t
+++ b/t/parse.t
@@ -60,4 +60,21 @@ FILE
     };
 }
 
+{
+    my $die;
+    local $SIG{__DIE__} = sub { $die = $_[0] };
+
+    my $r = write_cpanfile(<<FILE);
+configure_requires 'ExtUtils::MakeMaker', 5.5;
+
+requires 'DBI';
+requires 'Plack', '0.9970';
+ILLEGAL  'Moose', '< 0.8';
+FILE
+
+    eval { my $file = Module::CPANfile->load };
+
+    like $die, qr/failed: syntax error at \(eval \d+\) line 5,/;
+}
+
 done_testing;


### PR DESCRIPTION
I fixed a problem that showing wrong line number at which an parsing error occurred.
e.g. https://gist.github.com/moznion/5261898

But I have no neat idea, so way of this pull-request maybe uncouth...
