### PR TITLE
support cpanfile extra args

### DIFF
--- a/lib/Module/CPANfile.pm
+++ b/lib/Module/CPANfile.pm
@@ -319,13 +319,24 @@ sub new {
 
     # requires 'Plack';
     # requires 'Plack', '0.9970';
-    # requires 'Plack', git => 'git://github.com/plack/Plack.git', revision => '0.9970';
-    # requires 'Plack', '0.9970', git => 'git://github.com/plack/Plack.git', revision => '0.9970';
+    # requires 'Plack', git => 'git://github.com/plack/Plack.git', rev => '0.9970';
+    # requires 'Plack', '0.9970', git => 'git://github.com/plack/Plack.git', rev => '0.9970';
 
     $args{version} ||= 0;
 
-    bless +{ %args }, $class;
+    bless +{
+        name    => $args{name},
+        version => $args{version},
+        (exists $args{git} ? (git => $args{git}) : ()),
+        (exists $args{rev} ? (rev => $args{rev}) : ()),
+    }, $class;
 }
+
+sub name    { shift->{name} }
+sub version { shift->{version} }
+
+sub git { shift->{git} }
+sub rev { shift->{rev} }
 
 package Module::CPANfile;
 

--- a/t/requirement.t
+++ b/t/requirement.t
@@ -18,7 +18,7 @@ use t::Utils;
 subtest 'full set' => sub {
     my $r = write_cpanfile(<<FILE);
 requires 'Plack', '0.9970',
-    git => 'git://github.com/plack/Plack.git', revision => '0.9970';
+    git => 'git://github.com/plack/Plack.git', rev => '0.9970';
 FILE
 
     my $file = Module::CPANfile->load;
@@ -33,17 +33,17 @@ FILE
     my $got = $file->prereq_specs->{runtime}->{requires}->{Plack};
     isa_ok $got, 'Module::CPANfile::Requirement';
     is_deeply $got->as_hashref, {
-        name     => 'Plack',
-        version  => '0.9970',
-        git      => 'git://github.com/plack/Plack.git',
-        revision => '0.9970',
+        name    => 'Plack',
+        version => '0.9970',
+        git     => 'git://github.com/plack/Plack.git',
+        rev     => '0.9970',
     };
 };
 
 subtest 'drop version' => sub {
     my $r = write_cpanfile(<<FILE);
 requires 'Plack', # drop version
-    git => 'git://github.com/plack/Plack.git', revision => '0.9970';
+    git => 'git://github.com/plack/Plack.git', rev => '0.9970';
 FILE
 
     my $file = Module::CPANfile->load;
@@ -58,10 +58,10 @@ FILE
     my $got = $file->prereq_specs->{runtime}->{requires}->{Plack};
     isa_ok $got, 'Module::CPANfile::Requirement';
     is_deeply $got->as_hashref, {
-        name     => 'Plack',
-        version  => '0',
-        git      => 'git://github.com/plack/Plack.git',
-        revision => '0.9970',
+        name    => 'Plack',
+        version => '0',
+        git     => 'git://github.com/plack/Plack.git',
+        rev     => '0.9970',
     };
 };
 


### PR DESCRIPTION
```
requires 'Plack';
requires 'Plack', '0.9970';
requires 'Plack', git => 'git://github.com/plack/Plack.git', revision => '0.9970';
requires 'Plack', '0.9970', git => 'git://github.com/plack/Plack.git', revision => '0.9970';

# and

requires 'git://github.com/plack/Plack.git';
requires 'git://github.com/plack/Plack.git@0.9970';
```

are okay.
