### PR TITLE
t/parse.t: Handle systems without setlocale/LC_ALL

### DIFF
--- a/t/parse.t
+++ b/t/parse.t
@@ -1,18 +1,24 @@
 use strict;
 use Module::CPANfile;
 use Test::More;
+use Config;
 use POSIX qw(locale_h);
 use t::Utils;
 
 {
     # Use the traditional UNIX system locale to check the error message string.
-    my $old_locale = setlocale(LC_ALL);
-    setlocale(LC_ALL, 'C');
+    my $old_locale;
+    if ( $Config{d_setlocale} ) { 
+        $old_locale = setlocale(&LC_ALL);
+        setlocale(&LC_ALL, 'C');
+    }
     eval {
         my $file = Module::CPANfile->load('foo');
     };
     like $@, qr/No such file/;
-    setlocale(LC_ALL, $old_locale);
+    if ( $Config{d_setlocale} ) { 
+        setlocale(&LC_ALL, $old_locale);
+    }
 }
 
 {


### PR DESCRIPTION
The subject says it all, really :) Like other similar patches, this came up when smoking CPAN on Android.
