### PR TITLE
Merge multiple requirements for a module

### DIFF
--- a/lib/Module/CPANfile/Prereqs.pm
+++ b/lib/Module/CPANfile/Prereqs.pm
@@ -59,7 +59,11 @@ sub build_cpan_meta {
     my $prereq_spec = {};
     $self->prereq_each($identifier, sub {
         my $prereq = shift;
-        $prereq_spec->{$prereq->phase}{$prereq->type}{$prereq->module} = $prereq->requirement->version;
+        if (my $original = $prereq_spec->{$prereq->phase}{$prereq->type}{$prereq->module}) {
+            $prereq_spec->{$prereq->phase}{$prereq->type}{$prereq->module} = $original . ', ' . $prereq->requirement->version;
+        } else {
+            $prereq_spec->{$prereq->phase}{$prereq->type}{$prereq->module} = $prereq->requirement->version;
+        }
     });
 
     CPAN::Meta::Prereqs->new($prereq_spec);

--- a/t/parse.t
+++ b/t/parse.t
@@ -71,4 +71,36 @@ FILE
     };
 }
 
+{
+    my $r = write_cpanfile(<<FILE);
+requires 'Plack';
+requires 'Plack', '0.9970';
+requires 'Plack', '<= 1.0';
+requires 'Plack';
+FILE
+
+    my $file = Module::CPANfile->load;
+    my $prereq = $file->prereq;
+
+    is_deeply $prereq->as_string_hash, {
+        runtime => {
+            requires => { 'Plack' => '>= 0.9970, <= 1.0' },
+        },
+    };
+}
+
+{
+    my $r = write_cpanfile(<<FILE);
+requires 'Plack', '0.9970';
+requires 'Plack', '<= 0.8';
+FILE
+
+    my $file = Module::CPANfile->load;
+    eval {
+        my $prereq = $file->prereq;
+    };
+    like($@, qr/illegal requirements: minimum exceeds maximum/, 'Incompatible version ranges cause error');
+}
+
+
 done_testing;


### PR DESCRIPTION
Currently, if requirement for module is listed multiple times, the version from the last declaration overrides any previous requires. This can produce unexpected behavior when there are duplicate declarations with versions. This can happen when including multiple files; we use git submodules with cpanfile included into main project with "do". But this could happen with large files or merges. This could produce an error.

It would be better if the versions from the declarations were combined. Versions are combined with a comma to produce version ranges. Illegal ranges produce errors in CPAN::Meta::Requirements. CPAN::Meta::Requirements handles combining ranges to produce the inclusive range.
