### PR TITLE
cpanfile.pod: Link to cpanfile-dump

### DIFF
--- a/lib/cpanfile.pod
+++ b/lib/cpanfile.pod
@@ -108,6 +108,8 @@ L<Dist::Zilla::Plugin::Prereqs::FromCPANfile>,
 L<Module::Install::CPANfile>, so that C<cpanfile> can be used to
 describe dependencies for a CPAN distribution as well.
 
+The L<cpanfile-dump> tool can be used to dump dependencies.
+
 =head1 AUTHOR
 
 Tatsuhiko Miyagawa


### PR DESCRIPTION
In cpanfile.pod, add a link to cpanfile-dump.