### PR TITLE
perl-5.26.0 compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Makefile
 /Module-CPANfile-*
 /.build
 !META.json
+/blib
+pm_to_blib

--- a/t/feature.t
+++ b/t/feature.t
@@ -1,6 +1,7 @@
 use strict;
 use Module::CPANfile;
 use Test::More;
+use lib ".";
 use t::Utils;
 
 {

--- a/t/from_prereqs.t
+++ b/t/from_prereqs.t
@@ -2,6 +2,7 @@ use strict;
 use Test::More;
 
 use Module::CPANfile;
+use lib ".";
 use t::Utils;
 
 {

--- a/t/merge.t
+++ b/t/merge.t
@@ -1,6 +1,7 @@
 use strict;
 use Module::CPANfile;
 use Test::More;
+use lib ".";
 use t::Utils;
 
 {

--- a/t/mirror.t
+++ b/t/mirror.t
@@ -1,6 +1,7 @@
 use strict;
 use Module::CPANfile;
 use Test::More;
+use lib ".";
 use t::Utils;
 
 {

--- a/t/parse.t
+++ b/t/parse.t
@@ -2,6 +2,7 @@ use strict;
 use Module::CPANfile;
 use Test::More;
 use POSIX qw(locale_h);
+use lib ".";
 use t::Utils;
 
 {

--- a/t/requirement.t
+++ b/t/requirement.t
@@ -1,6 +1,7 @@
 use strict;
 use Module::CPANfile;
 use Test::More;
+use lib ".";
 use t::Utils;
 
 {


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  The tests in
this distribution need to be adjusted in order to properly locate
./t/Utils.pm.

For:  https://github.com/miyagawa/cpanfile/issues/47