### PR TITLE
Validate on phase names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
-sudo: false
 language: perl
-perl:
-  - 5.26
-  - 5.24
-  - 5.22
-  - "5.20"
-  - 5.18
-  - 5.16
-  - 5.14
-  - 5.12
-  - "5.10"
+os: linux
+dist: xenial
+jobs:
+  - perl: 5.26
+  - perl: 5.24
+  - perl: 5.22
+  - perl: "5.20"
+  - perl: 5.18
+  - perl: 5.16
+  - perl: 5.14
+  - perl: 5.12
+    dist: trusty
+  - perl: "5.10"
+    dist: trusty

--- a/lib/Module/CPANfile/Environment.pm
+++ b/lib/Module/CPANfile/Environment.pm
@@ -68,10 +68,16 @@ sub prereqs { $_[0]->{prereqs} }
 
 sub mirrors { $_[0]->{mirrors} }
 
+sub _validate_phase {
+    die "Phase '$_' not recognised"
+        unless !!($_ =~ qr/^(configure|build|develop|runtime|test)$/);
+}
+
 # DSL goes from here
 
 sub on {
     my($self, $phase, $code) = @_;
+    _validate_phase() for $phase;
     local $self->{phase} = $phase;
     $code->();
 }

--- a/t/parse.t
+++ b/t/parse.t
@@ -72,4 +72,16 @@ FILE
     };
 }
 
+subtest 'validate on phase names' => sub {
+    my $r = write_cpanfile(<<FILE);
+requires 'Ok';
+on question => sub {
+    suggests Answer => 42;
+};
+FILE
+
+    my $file = eval { Module::CPANfile->load; };
+    like $@, qr/Phase 'question' not recognised/, 'question is not known';
+};
+
 done_testing;


### PR DESCRIPTION
Fix for #14.

Parsing will now throw an exception for unrecognised phases.

```
Parsing /tmp/pOEhp3im89/cpanfile failed: Phase 'question' not recognised at /.../Module/CPANfile/Environment.pm line 72.
```

Allowed phases are *configure*, *build*, *develop*, *runtime*, and *test*.