### PR TITLE
Add optional sub to mirror keyword

### DIFF
--- a/lib/Module/CPANfile.pm
+++ b/lib/Module/CPANfile.pm
@@ -155,7 +155,7 @@ sub to_string {
     my $prereqs = $self->prereq_specs;
 
     my $code = '';
-    $code .= $self->_dump_mirrors($mirrors);
+    $code .= $self->_dump_mirrors($mirrors, $prereqs);
     $code .= $self->_dump_prereqs($prereqs, $include_empty);
 
     for my $feature ($self->features) {
@@ -169,9 +169,41 @@ sub to_string {
 }
 
 sub _dump_mirrors {
-    my($self, $mirrors) = @_;
+    my ($self, $mirrors, $prereqs) = @_;
 
     my $code = "";
+    my ($nomirror, %bymirror) = '__no_mirror__';
+    if (@$mirrors) {
+
+        # reshape runtime phases to key on mirror url
+        for my $phase (qw(runtime)) {
+            for my $type (qw(requires recommends suggests conflicts)) {
+                for my $mod(sort keys %{$prereqs->{$phase}{$type}}) {
+                    my $options = $self->options_for_module($mod) || {};
+                    my $mirror  = $options->{mirror} || $nomirror;
+                    $bymirror{$mirror}{$phase}{$type}{$mod} =
+                        $prereqs->{$phase}{$type}{$mod};
+                    delete $prereqs->{$phase}{$type}{$mod} if $mirror eq $nomirror;
+                }
+            }
+        }
+
+        # write those without a mirror first - (occur before 'mirror' statement)
+        $code .= $self->_dump_prereqs(delete($bymirror{$nomirror}), 0, 0)
+            if $bymirror{$nomirror};
+    }
+
+    # remove file scope mirrors to process mirror blocks and mirror options
+    delete @bymirror{@$mirrors};
+
+    # mirror 'url' => sub { };
+    for my $url(sort keys %bymirror) {
+        $code .= "mirror '$url' => sub {\n";
+        $code .= $self->_dump_prereqs($bymirror{$url}, 0, 4);
+        delete(@{$prereqs->{runtime}{$_}}{keys %{$bymirror{$url}{runtime}{$_}}})
+            for (qw(requires recommends suggests conflicts));
+        $code .= "};\n";
+    }
 
     for my $url (@$mirrors) {
         $code .= "mirror @{[ _d $url ]};\n";
@@ -200,9 +232,13 @@ sub _dump_prereqs {
                              : "${indent}$type @{[ _d $mod ]}, @{[ _d $ver ]}";
 
                 my $options = $self->options_for_module($mod) || {};
+
+                # mirror only options handled as mirror 'url' => sub { ... };
+                delete($options->{mirror})
+                    if ($phase eq 'runtime' && !exists $options->{dist});
                 if (%$options) {
                     my @opts;
-                    for my $key (keys %$options) {
+                    for my $key (sort keys %$options) {
                         my $k = $key =~ /^[a-zA-Z0-9_]+$/ ? $key : _d $key;
                         push @opts, "$k => @{[ _d $options->{$k} ]}";
                     }

--- a/lib/Module/CPANfile.pm
+++ b/lib/Module/CPANfile.pm
@@ -231,7 +231,7 @@ sub _dump_prereqs {
                              ? "${indent}$type @{[ _d $mod ]}"
                              : "${indent}$type @{[ _d $mod ]}, @{[ _d $ver ]}";
 
-                my $options = $self->options_for_module($mod) || {};
+                my $options = { %{$self->options_for_module($mod) || {}} };
 
                 # mirror only options handled as mirror 'url' => sub { ... };
                 delete($options->{mirror})

--- a/lib/Module/CPANfile/Environment.pm
+++ b/lib/Module/CPANfile/Environment.pm
@@ -98,8 +98,13 @@ sub feature {
 sub osname { die "TODO" }
 
 sub mirror {
-    my($self, $url) = @_;
-    push @{$self->{mirrors}}, $url;
+    my($self, $url, $code) = @_;
+    if ($code) {
+        local $self->{mirrors} = [$url];
+        $code->();
+    } else {
+        push @{$self->{mirrors}}, $url;
+    }
 }
 
 sub requirement_for {
@@ -137,6 +142,9 @@ sub conflicts {
 
 sub add_prereq {
     my($self, $type, $module, @args) = @_;
+
+    my $mirrors = $self->mirrors;
+    splice @args, (@args % 2), 0, mirror => $mirrors->[-1] if @$mirrors;
 
     $self->prereqs->add(
         feature => $self->{feature},

--- a/lib/cpanfile.pod
+++ b/lib/cpanfile.pod
@@ -88,6 +88,21 @@ L<CPAN::Meta::Spec/optional_features> for more details.
 Shortcut for C<requires> in specific phase. This is mainly provided
 for compatibilities with L<Module::Install> DSL.
 
+=item mirror
+
+  # file level mirrors - last until next mirror or EOF
+  mirror 'https://backpan.perl.org';
+  requires 'LWP::Parallel' => '== 2.34';
+  # change mirror
+  mirror 'https://cpan.metacpan.org';
+  requires 'DBD::SQLite' => '1.60';
+
+  # scoped for requirements in the block
+  mirror 'https://backpan.perl.org' => sub {
+    requires 'LWP::ParallelUA' => '== 2.34';
+    requires 'DBD::SQLite' => '== 1.46'
+  };
+
 =back
 
 =head1 USAGE

--- a/t/mirror.t
+++ b/t/mirror.t
@@ -36,4 +36,152 @@ FILE
     like $file->to_string, qr{mirror 'http://backpan.cpan.org';};
 }
 
+subtest 'multiple mirrors - multiple definition styles' => sub {
+    my $r = write_cpanfile(<<FILE);
+
+# no mirror
+requires 'Try::Tiny';
+
+mirror 'http://pause.local' => sub {
+    requires 'Secret::Module' => '0.1';
+    requires 'Secret::Sauce';
+    suggests 'Secrets::Manager';
+};
+
+mirror 'https://backpan.perl.org';
+
+requires 'Hash::MultiValue' => '0.08';
+
+requires 'Cookie::Monster' => '0.01',
+    mirror => 'http://cpan.monstrous.com',
+    url => 'http://cpan.monstrous.com/cpan/authors/id/C/CO/COO/Cookie-Monster-0.01.tar.gz';
+
+on test => sub {
+    requires 'Test::More' => '0.83',
+        mirror => 'https://cpantesters.org';
+};
+
+FILE
+
+    my $file = Module::CPANfile->load;
+    is_deeply $file->prereq->as_string_hash, {
+        runtime => {
+            requires => {
+                'Cookie::Monster'  => '0.01',
+                'Hash::MultiValue' => '0.08',
+                'Secret::Module'   => '0.1',
+                'Secret::Sauce'    => 0,
+                'Try::Tiny'        => 0,
+            },
+            suggests => {'Secrets::Manager' => 0}
+        },
+        test => {
+            requires => {'Test::More' => '0.83'}
+        }
+    };
+
+    my $mirrors = $file->mirrors;
+    is_deeply $mirrors, ['https://backpan.perl.org'], 'correct mirror';
+
+    # test comprehension and round trip.
+    my $file_string = $file->to_string;
+    like $file_string, qr{^requires 'Try::Tiny';}s, 'no mirror - first thing';
+    like $file_string, qr{mirror 'http://pause\.local' => sub \{}, 'block start';
+    like $file_string, qr{mirror 'http://cpan.monstrous.com' => sub \{
+\s+requires 'Cookie::Monster', '0.01',
+\s+url => 'http://cpan.monstrous.com/cpan/authors/id/C/CO/COO/Cookie-Monster-0.01.tar.gz';
+\s*\}}m, 'mirror block with url - n.b. mirror will likely be ignored by cpanm';
+
+    like $file_string,
+        qr{mirror 'https://backpan.perl.org';\nrequires 'Hash::MultiValue', '0.08';}m,
+        'file level mirror';
+
+    like $file_string, qr{on test => sub \{
+\s+requires 'Test::More', '0.83',
+\s+mirror => 'https://cpantesters.org';
+\s*\};}m, 'mirror options included';
+
+    # diag $file_string;
+};
+
+subtest 'mirror scope for on block' => sub {
+    my $r = write_cpanfile(<<FILE);
+
+on develop => sub {
+    mirror 'https://pause.local';
+    requires 'Test::More::Secret';
+};
+FILE
+
+    my $file = Module::CPANfile->load;
+    is_deeply $file->prereq->as_string_hash, {
+        develop => {
+            requires => {'Test::More::Secret' => '0'}
+        }
+    };
+
+    my $mirrors = $file->mirrors;
+
+    # mirror remains file scope despite apparent ANON sub scope.
+    is_deeply $mirrors, ['https://pause.local'], 'no blocks mark scope level';
+
+    my $file_string = $file->to_string;
+    like $file_string, qr{^mirror 'https://pause\.local';}s, 'DSL limitation';
+    like $file_string, qr{mirror => 'https://pause\.local';}, 'unfortunate duplication';
+    # diag $file_string;
+};
+
+
+subtest 'mirror and dist options' => sub {
+    my $r = write_cpanfile(<<FILE);
+
+requires 'XYZ',
+    mirror => 'http://darkpan.company.com';
+
+requires 'Hash::MultiValue' => '0.08',
+    dist => 'MIYAGAWA/Hash-MultiValue-0.08.tar.gz',
+    mirror => 'https://backpan.perl.org';
+
+on develop => sub {
+    mirror 'https://pause.local';
+    requires 'Test::More::Secret',
+    dist => 'MY/Test-More-Secret-10000a.tar.gz';
+};
+FILE
+
+    my $file = Module::CPANfile->load;
+    is_deeply $file->prereq->as_string_hash, {
+        runtime => {
+            requires => {'Hash::MultiValue' => '0.08', XYZ => 0}
+        },
+        develop => {
+            requires => {'Test::More::Secret' => '0'}
+        }
+    };
+
+    my $mirrors = $file->mirrors;
+
+    # mirror remains file scope despite apparent ANON sub scope.
+    is_deeply $mirrors, ['https://pause.local'], 'no blocks mark scope level';
+
+    my $file_string = $file->to_string;
+    is $file_string, <<'EOF', 'blocks preferred, options "promoted"';
+mirror 'http://darkpan.company.com' => sub {
+    requires 'XYZ';
+};
+mirror 'https://backpan.perl.org' => sub {
+    requires 'Hash::MultiValue', '0.08',
+      dist => 'MIYAGAWA/Hash-MultiValue-0.08.tar.gz',
+      mirror => 'https://backpan.perl.org';
+};
+mirror 'https://pause.local';
+on develop => sub {
+    requires 'Test::More::Secret',
+      dist => 'MY/Test-More-Secret-10000a.tar.gz',
+      mirror => 'https://pause.local';
+};
+EOF
+};
+
+
 done_testing;


### PR DESCRIPTION
Patch to support adding to the DSL syntax as discussed in miyagawa/cpanminus#473  specifically - https://github.com/miyagawa/cpanminus/pull/473#issuecomment-136029302

```perl
mirror $url => sub { requires $name => $version; ... };
```
In addition the latest `mirror => $url` will be added to each following requirement, as also discussed above.

In all cases `$cpanfile->options_for_module($name)` will result in a hash reference that contains a `mirror` key. This is designed for `Menlo::CLI::Compat->resolve_name` to search the specified mirror as it passes through to `Menlo::Dependency` there.